### PR TITLE
fuse-xfs: Change dependency from osxfuse to macFUSE

### DIFF
--- a/fuse-xfs.rb
+++ b/fuse-xfs.rb
@@ -1,20 +1,48 @@
+class MacFuseRequirement < Requirement
+  fatal true
+
+  satisfy(build_env: false) { self.class.binary_mac_fuse_installed? }
+
+  def self.binary_mac_fuse_installed?
+    File.exist?("/usr/local/include/fuse.h") &&
+      !File.symlink?("/usr/local/include")
+  end
+
+  env do
+    ENV.append_path "PKG_CONFIG_PATH", HOMEBREW_LIBRARY/"Homebrew/os/mac/pkgconfig/fuse"
+
+    unless HOMEBREW_PREFIX.to_s == "/usr/local"
+      ENV.append_path "HOMEBREW_LIBRARY_PATHS", "/usr/local/lib"
+      ENV.append_path "HOMEBREW_INCLUDE_PATHS", "/usr/local/include/fuse"
+    end
+  end
+
+  def message
+    "macFUSE is required. Please run `brew install --cask macfuse` first."
+  end
+end
+
 class FuseXfs < Formula
-  desc "Read-only XFS driver for OSXFUSE"
+  desc "Read-only XFS driver for macFUSE"
   homepage "https://fusexfs.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/fusexfs/releases/fuse-xfs-0.2.1.tar.gz"
   sha256 "4c16e3efbb8adbe47c9ee5fc20781bd5f19c33638b78140fdc5d643b6bf6c140"
   head "http://hg.code.sf.net/p/fusexfs/trunk", :using => :hg
 
+  depends_on MacFuseRequirement => :build
+  depends_on "pkg-config" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on :osxfuse
 
   def install
     ENV.deparallelize
 
     # Building the DMG requires root, so we don't build it
     inreplace "src/Makefile", "all: $(PROGRAMS) $(DMG)", "all: $(PROGRAMS)"
+
+    # TODO: It would be better to do this as a patch.
+    inreplace "src/Make.inc", "osxfuse", "fuse"
 
     cd "src" do
       system "make"


### PR DESCRIPTION
Some additional context here:
- https://github.com/Homebrew/brew/issues/9401
- https://github.com/gerard/ext4fuse/issues/66

Existing installs might need to uninstall and reinstall like so:

- `brew rm --cask osxfuse`
- `brew install --cask macfuse`
- `brew uninstall fuse-xfs`
- `brew install fuse-xfs`